### PR TITLE
Python 3 uses a different integer division operator

### DIFF
--- a/miette/doc.py
+++ b/miette/doc.py
@@ -81,7 +81,7 @@ class DocReader(object):
                 length = size - len(data_buffer)
 
             if fc_f_compressed:
-                fc_fc /= 2
+                fc_fc //= 2
             else:
                 length *= 2
 


### PR DESCRIPTION
Replaced `/=` with `//=` to avoid errors on the line `self.word_document.seek(fc_fc)`. Python 3 uses floating point division by default with the `/=` operator, but we need an integer data type.